### PR TITLE
updating SSSOM header to include contributors names

### DIFF
--- a/dwc-mixs/mapping/DwC-MIxS_mappingSemantic.sssom.tsv
+++ b/dwc-mixs/mapping/DwC-MIxS_mappingSemantic.sssom.tsv
@@ -2,30 +2,44 @@
 #dcterms:license: CC-BY
 #version: Version 1
 #creator_id:
-#  -https://orcid.org/0000-0003-1336-5554
-#  -https://orcid.org/0000-0001-9625-1899
-#  -https://orcid.org/0000-0002-6601-2165
-#  -https://orcid.org/0000-0003-1144-0290
-#  -https://orcid.org/0000-0002-8083-6048
-#  -https://orcid.org/0000-0003-3770-3714
-#  -https://orcid.org/0000-0002-4366-3088
-#  -https://orcid.org/0000-0002-4236-0384
-#  -https://orcid.org/0000-0001-8815-0078
-#  -https://orcid.org/0000-0002-2996-719X
-#  -https://orcid.org/0000-0001-9401-8460
-#  -https://orcid.org/0000-0003-1691-239X
-#  -https://orcid.org/0000-0001-6215-3617
-#  -https://orcid.org/0000-0002-3237-4547
-#  -https://orcid.org/0000-0001-7087-2646
+#  - https://orcid.org/0000-0002-3237-4547
+#  - https://orcid.org/0000-0002-4366-3088
+#  - https://orcid.org/0000-0002-8083-6048
+#  - https://orcid.org/0000-0001-9625-1899
+#  - https://orcid.org/0000-0001-7087-2646
+#  - https://orcid.org/0000-0002-2996-719X
+#  - https://orcid.org/0000-0002-6601-2165
+#  - https://orcid.org/0000-0002-4236-0384
+#  - https://orcid.org/0000-0001-6215-3617
+#  - https://orcid.org/0000-0003-1691-239X
+#  - https://orcid.org/0000-0001-9401-8460
+#  - https://orcid.org/0000-0003-3770-3714
+#  - https://orcid.org/0000-0001-8815-0078
+#  - https://orcid.org/0000-0003-1144-0290
+#creator_name:
+#  - Ward Appeltans
+#  - Pier Luigi Buttigieg
+#  - Mariya Dimitrova
+#  - Willam D. Duncan
+#  - Yi-Ming Gan
+#  - Raïssa Meyer
+#  - Christopher Mungall
+#  - Pieter Provoost
+#  - Tim Robertson
+#  - Thomas Stjernegaard Jeppesen
+#  - Saara Suominen
+#  - Maxime Sweetlove
+#  - Ramona L. Walls
+#  - John Wieczorek
 #curie_map:
-#  dwc: http://rs.tdwg.org/dwc/terms/
-#  dwcversion: http://rs.tdwg.org/dwc/terms/version/
-#  dcterms: http://purl.org/dc/terms/
-#  dcversion: http://dublincore.org/usage/terms/history/
-#  MIXS: https://w3id.org/gensc/terms/MIXS:
-#  MIXSversion: https://github.com/GenomicsStandardsConsortium/mixs-legacy/blob/master/mixs5/
-#  orcid: https://orcid.org/
-#  skos: http://www.w3.org/2004/02/skos/core
+#  - dwc: http://rs.tdwg.org/dwc/terms/
+#  - dwcversion: http://rs.tdwg.org/dwc/terms/version/
+#  - dcterms: http://purl.org/dc/terms/
+#  - dcversion: http://dublincore.org/usage/terms/history/
+#  - MIXS: https://w3id.org/gensc/terms/MIXS:
+#  - MIXSversion: https://github.com/GenomicsStandardsConsortium/mixs-legacy/blob/master/mixs5/
+#  - orcid: https://orcid.org/
+#  - skos: http://www.w3.org/2004/02/skos/core
 subject_id	subject_label	subject_category	predicate_id	predicate_label	object_id	object_label	object_category	match_type	creator_id	subject_source	subject_source_version	object_source	object_source_version	mapping_date	comment
 dwc:verbatimCoordinates	Verbatim Coordinates	https://dwc.tdwg.org/list/#dcterms_Location	skos:broadMatch	broad match to	MIXS:0000009	lat_lon	MIxS core	HumanCurated	orcid:0000-0003-1144-0290	dwc:verbatimCoordinates	dwcversion:verbatimCoordinates-2017-10-06	MIXSversion:mixs_v5.xlsx	5	2021-02-09	The Coordinate Reference System "epsg:4326" must be provided explicitly in dwc:verbatimSRS in order for the mapping to be complete.
 dwc:decimalLatitude	Decimal Latitude	https://dwc.tdwg.org/list/#dcterms_Location	skos:narrowMatch	narrow match to	MIXS:0000009	lat_lon	MIxS core	HumanCurated	orcid:0000-0002-2996-719X	dwc:decimalLatitude	dwcversion:decimalLatitude-2017-10-06	MIXSversion:mixs_v5.xlsx	5	2021-03-30	The DwC term only refers to half of the MIxS term

--- a/dwc-mixs/mapping/DwC-MIxS_mappingSupport.sssom.tsv
+++ b/dwc-mixs/mapping/DwC-MIxS_mappingSupport.sssom.tsv
@@ -2,30 +2,44 @@
 #dcterms:license: CC-BY
 #version: Version 1
 #creator_id:
-#  -https://orcid.org/0000-0003-1336-5554
-#  -https://orcid.org/0000-0001-9625-1899
-#  -https://orcid.org/0000-0002-6601-2165
-#  -https://orcid.org/0000-0003-1144-0290
-#  -https://orcid.org/0000-0002-8083-6048
-#  -https://orcid.org/0000-0003-3770-3714
-#  -https://orcid.org/0000-0002-4366-3088
-#  -https://orcid.org/0000-0002-4236-0384
-#  -https://orcid.org/0000-0001-8815-0078
-#  -https://orcid.org/0000-0002-2996-719X
-#  -https://orcid.org/0000-0001-9401-8460
-#  -https://orcid.org/0000-0003-1691-239X
-#  -https://orcid.org/0000-0001-6215-3617
-#  -https://orcid.org/0000-0002-3237-4547
-#  -https://orcid.org/0000-0001-7087-2646
+#  - https://orcid.org/0000-0002-3237-4547
+#  - https://orcid.org/0000-0002-4366-3088
+#  - https://orcid.org/0000-0002-8083-6048
+#  - https://orcid.org/0000-0001-9625-1899
+#  - https://orcid.org/0000-0001-7087-2646
+#  - https://orcid.org/0000-0002-2996-719X
+#  - https://orcid.org/0000-0002-6601-2165
+#  - https://orcid.org/0000-0002-4236-0384
+#  - https://orcid.org/0000-0001-6215-3617
+#  - https://orcid.org/0000-0003-1691-239X
+#  - https://orcid.org/0000-0001-9401-8460
+#  - https://orcid.org/0000-0003-3770-3714
+#  - https://orcid.org/0000-0001-8815-0078
+#  - https://orcid.org/0000-0003-1144-0290
+#creator_name:
+#  - Ward Appeltans
+#  - Pier Luigi Buttigieg
+#  - Mariya Dimitrova
+#  - Willam D. Duncan
+#  - Yi-Ming Gan
+#  - Raïssa Meyer
+#  - Christopher Mungall
+#  - Pieter Provoost
+#  - Tim Robertson
+#  - Thomas Stjernegaard Jeppesen
+#  - Saara Suominen
+#  - Maxime Sweetlove
+#  - Ramona L. Walls
+#  - John Wieczorek
 #curie_map:
-#  dwc: http://rs.tdwg.org/dwc/terms/
-#  dwcversion: http://rs.tdwg.org/dwc/terms/version/
-#  dcterms: http://purl.org/dc/terms/
-#  dcversion: http://dublincore.org/usage/terms/history/
-#  MIXS: https://w3id.org/gensc/terms/MIXS:
-#  MIXSversion: https://github.com/GenomicsStandardsConsortium/mixs-legacy/blob/master/mixs5/
-#  orcid: https://orcid.org/
-#  skos: http://www.w3.org/2004/02/skos/core
+#  - dwc: http://rs.tdwg.org/dwc/terms/
+#  - dwcversion: http://rs.tdwg.org/dwc/terms/version/
+#  - dcterms: http://purl.org/dc/terms/
+#  - dcversion: http://dublincore.org/usage/terms/history/
+#  - MIXS: https://w3id.org/gensc/terms/MIXS:
+#  - MIXSversion: https://github.com/GenomicsStandardsConsortium/mixs-legacy/blob/master/mixs5/
+#  - orcid: https://orcid.org/
+#  - skos: http://www.w3.org/2004/02/skos/core
 subject_id	subject_label	subject_definition	subject_valueSyntax	subject_category	predicate_id	predicate_label	syntax_predicate_id	syntax_predicate_label	object_id	object_label	object_definition	object_valueSyntax	object_category	match_type	creator_id	subject_source	subject_source_version	object_source	object_source_version	mapping_date	comment	syntax_comment
 dwc:verbatimCoordinates	Verbatim Coordinates	The verbatim original spatial coordinates of the Location. The coordinate ellipsoid, geodeticDatum, or full Spatial Reference System (SRS) for these coordinates should be stored in verbatimSRS and the coordinate system should be stored in verbatimCoordinateSystem.	verbatim	https://dwc.tdwg.org/list/#dcterms_Location	skos:broadMatch	broad match to	skos:relatedMatch	related match to	MIXS:0000009	lat_lon	The geographical origin of the sample as defined by latitude and longitude. The values should be reported in decimal degrees and in WGS84 system	{float} {float}	MIxS core	HumanCurated	orcid:0000-0003-1144-0290	dwc:verbatimCoordinates	dwcversion:verbatimCoordinates-2017-10-06	MIXSversion:mixs_v5.xlsx	5	2021-02-09	The Coordinate Reference System "epsg:4326" must be provided explicitly in dwc:verbatimSRS in order for the mapping to be complete.	The DwC term expects a verbatim input (so anything really), whereas MIxS expects decimal degrees input as {float} {float} 
 dwc:decimalLatitude	Decimal Latitude	The geographic latitude (in decimal degrees, using the spatial reference system given in geodeticDatum) of the geographic center of a Location. Positive values are north of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.	 	https://dwc.tdwg.org/list/#dcterms_Location	skos:narrowMatch	narrow match to	skos:narrowMatch	narrow match to	MIXS:0000009	lat_lon	The geographical origin of the sample as defined by latitude and longitude. The values should be reported in decimal degrees and in WGS84 system	{float} {float}	MIxS core	HumanCurated	orcid:0000-0002-2996-719X	dwc:decimalLatitude	dwcversion:decimalLatitude-2017-10-06	MIXSversion:mixs_v5.xlsx	5	2021-03-30	The DwC term only refers to half of the MIxS term	The DwC term expects decimal degrees, and so does MIxS - however, MIxS expects two input values, while DwC only expects one

--- a/dwc-mixs/mapping/DwC-MIxS_mappingSyntactic.sssom.tsv
+++ b/dwc-mixs/mapping/DwC-MIxS_mappingSyntactic.sssom.tsv
@@ -2,30 +2,44 @@
 #dcterms:license: CC-BY
 #version: Version 1
 #creator_id:
-#  -https://orcid.org/0000-0003-1336-5554
-#  -https://orcid.org/0000-0001-9625-1899
-#  -https://orcid.org/0000-0002-6601-2165
-#  -https://orcid.org/0000-0003-1144-0290
-#  -https://orcid.org/0000-0002-8083-6048
-#  -https://orcid.org/0000-0003-3770-3714
-#  -https://orcid.org/0000-0002-4366-3088
-#  -https://orcid.org/0000-0002-4236-0384
-#  -https://orcid.org/0000-0001-8815-0078
-#  -https://orcid.org/0000-0002-2996-719X
-#  -https://orcid.org/0000-0001-9401-8460
-#  -https://orcid.org/0000-0003-1691-239X
-#  -https://orcid.org/0000-0001-6215-3617
-#  -https://orcid.org/0000-0002-3237-4547
-#  -https://orcid.org/0000-0001-7087-2646
+#  - https://orcid.org/0000-0002-3237-4547
+#  - https://orcid.org/0000-0002-4366-3088
+#  - https://orcid.org/0000-0002-8083-6048
+#  - https://orcid.org/0000-0001-9625-1899
+#  - https://orcid.org/0000-0001-7087-2646
+#  - https://orcid.org/0000-0002-2996-719X
+#  - https://orcid.org/0000-0002-6601-2165
+#  - https://orcid.org/0000-0002-4236-0384
+#  - https://orcid.org/0000-0001-6215-3617
+#  - https://orcid.org/0000-0003-1691-239X
+#  - https://orcid.org/0000-0001-9401-8460
+#  - https://orcid.org/0000-0003-3770-3714
+#  - https://orcid.org/0000-0001-8815-0078
+#  - https://orcid.org/0000-0003-1144-0290
+#creator_name:
+#  - Ward Appeltans
+#  - Pier Luigi Buttigieg
+#  - Mariya Dimitrova
+#  - Willam D. Duncan
+#  - Yi-Ming Gan
+#  - Raïssa Meyer
+#  - Christopher Mungall
+#  - Pieter Provoost
+#  - Tim Robertson
+#  - Thomas Stjernegaard Jeppesen
+#  - Saara Suominen
+#  - Maxime Sweetlove
+#  - Ramona L. Walls
+#  - John Wieczorek
 #curie_map:
-#  dwc: http://rs.tdwg.org/dwc/terms/
-#  dwcversion: http://rs.tdwg.org/dwc/terms/version/
-#  dcterms: http://purl.org/dc/terms/
-#  dcversion: http://dublincore.org/usage/terms/history/
-#  MIXS: https://w3id.org/gensc/terms/MIXS:
-#  MIXSversion: https://github.com/GenomicsStandardsConsortium/mixs-legacy/blob/master/mixs5/
-#  orcid: https://orcid.org/
-#  skos: http://www.w3.org/2004/02/skos/core
+#  - dwc: http://rs.tdwg.org/dwc/terms/
+#  - dwcversion: http://rs.tdwg.org/dwc/terms/version/
+#  - dcterms: http://purl.org/dc/terms/
+#  - dcversion: http://dublincore.org/usage/terms/history/
+#  - MIXS: https://w3id.org/gensc/terms/MIXS:
+#  - MIXSversion: https://github.com/GenomicsStandardsConsortium/mixs-legacy/blob/master/mixs5/
+#  - orcid: https://orcid.org/
+#  - skos: http://www.w3.org/2004/02/skos/core
 subject_id	subject_label	subject_category	syntax_predicate_id	object_id	object_label	object_category	match_type	creator_id	subject_source	subject_source_version	object_source	object_source_version	mapping_date	syntax_comment
 dwc:verbatimCoordinates	Verbatim Coordinates	https://dwc.tdwg.org/list/#dcterms_Location	skos:relatedMatch	MIXS:0000009	lat_lon	MIxS core	HumanCurated	orcid:0000-0003-1144-0290	dwc:verbatimCoordinates	dwcversion:verbatimCoordinates-2017-10-06	MIXSversion:mixs_v5.xlsx	5	2021-02-09	The DwC term expects a verbatim input (so anything really), whereas MIxS expects decimal degrees input as {float} {float} 
 dwc:decimalLatitude	Decimal Latitude	https://dwc.tdwg.org/list/#dcterms_Location	skos:narrowMatch	MIXS:0000009	lat_lon	MIxS core	HumanCurated	orcid:0000-0002-2996-719X	dwc:decimalLatitude	dwcversion:decimalLatitude-2017-10-06	MIXSversion:mixs_v5.xlsx	5	2021-03-30	The DwC term expects decimal degrees, and so does MIxS - however, MIxS expects two input values, while DwC only expects one


### PR DESCRIPTION
addressing #69, the SSSOM header has been updated to include contributors names. The ORCIDs and names were rearranged to follow alphabetical order based on the last names and names of non-contributing members were removed.

Additionally, I've updated the structure of the CURIE block to follow the yaml list syntax